### PR TITLE
Update resource-parser.js

### DIFF
--- a/Scripts/resource-parser.js
+++ b/Scripts/resource-parser.js
@@ -590,7 +590,7 @@ function V2QX(subs,Pudp,Ptfo,Pcert,Ptls13){
 		ss=JSON.parse(server);
 		ip="vmess="+ss.add+":"+ss.port;
 		pwd="password="+ss.id;
-		mtd="method=aes-128-gcm"
+		mtd="method=none"
 		tag="tag="+decodeURIComponent(ss.ps);
 		udp= Pudp==1? "udp-relay=true":"udp-relay=false";
 		tfo= Ptfo==1? "fast-open=true":"fast-open=false";


### PR DESCRIPTION
默认更改为不加密，大多数外层套了tls加密，vmess再加密浪费性能