### PR TITLE
fix "@" symbol in replace

### DIFF
--- a/Scripts/resource-parser.js
+++ b/Scripts/resource-parser.js
@@ -128,7 +128,7 @@ var Preg = mark0 && para1.indexOf("regex=") != -1 ? decodeURIComponent(para1.spl
 var Pregdel = mark0 && para1.indexOf("delreg=") != -1 ? decodeURIComponent(para1.split("delreg=")[1].split("&")[0]) : null; // 正则删除参数
 var Phin0 = mark0 && para1.indexOf("inhn=") != -1 ? (para1.split("inhn=")[1].split("&")[0].split("+")).map(decodeURIComponent) : null; //hostname 
 var Phout0 = mark0 && para1.indexOf("outhn=") != -1 ? (para1.split("outhn=")[1].split("&")[0].split("+")).map(decodeURIComponent) : null; //hostname
-var Preplace = mark0 && para1.indexOf("replace=") != -1 ? decodeURIComponent(para1.split("replace=")[1].split("&")[0]) : null; //filter/rewrite 正则替换
+var Preplace = mark0 && para1.indexOf("replace=") != -1 ? para1.split("replace=")[1].split("&")[0] : null; //filter/rewrite 正则替换
 var Pemoji = mark0 && para1.indexOf("emoji=") != -1 ? para1.split("emoji=")[1].split("&")[0] : null;
 var Pudp0 = mark0 && para1.indexOf("udp=") != -1 ? para1.split("udp=")[1].split("&")[0] : 0;
 var Ptfo0 = mark0 && para1.indexOf("tfo=") != -1 ? para1.split("tfo=")[1].split("&")[0] : 0;
@@ -832,12 +832,12 @@ function Domain2Rule(content) {
 function ReplaceReg(cnt, para) {
     var cnt0 = cnt//.join("\n")
     //$notify("0","",cnt0)
-    var pp = para.split("+")
+    var pp = para.split("+");
     for (var i = 0; i < pp.length; i++) {
-        var p1 = pp[i].split("@")[0]
-        var p2 = pp[i].split("@")[1]
-        p1 = new RegExp(p1, "gmi")
-        cnt0 = cnt0.map(item => item.replace(p1, p2))
+        var p1 = decodeURIComponent(pp[i].split("@")[0]);
+        var p2 = decodeURIComponent(pp[i].split("@")[1]);
+        p1 = new RegExp(p1, "gmi");
+        cnt0 = cnt0.map(item => item.replace(p1, p2));
         //$notify(p1,p2,cnt0)
     }
   //$notify("1","",cnt0)


### PR DESCRIPTION
当在replace中使用“@”符号作为替换对象时会出错。如：
```
replace=https://raw.githubusercontent.com\/(.*?)\/(.*?)\/(.*)@https://cdn.jsdelivr.net/gh/$1/$2@$3
or
replace=https://raw.githubusercontent.com\/(.*?)\/(.*?)\/(.*)@https://cdn.jsdelivr.net/gh/$1/$2%40$3
```
原因在于，第一步解析replace参数时，就会将"%40" decode 成 “@”。从而在之后的 replace 中使用 “@” 分割正则表达式和替换表达时出错。因此把 urldecode 延后在分割之后分别进行。这时使用如下参数就可以替换成功：
```
replace=https://raw.githubusercontent.com\/(.*?)\/(.*?)\/(.*)@https://cdn.jsdelivr.net/gh/$1/$2%40$3
--->
https://cdn.jsdelivr.net/gh/username/repo@master/bala/bala.txt
```