### PR TITLE
Update resource-parser.js

### DIFF
--- a/Scripts/resource-parser.js
+++ b/Scripts/resource-parser.js
@@ -1427,7 +1427,7 @@ function rule_list_handle(cnt) {
     } else if (cnt.indexOf("payload:")==-1) { //host - suffix, not clash rule list
       //$notify("xxx","xxxx",cnt)
       cnt=cnt.replace(/'|"/g,"").trim()//replace(/'|"|\+\.|\*\.|\*\.\*/g,"") 2023-04-10
-      if(!/\*|\+/.test(cnt[0])) {
+      if(!/\*|\+/.test(cnt[0]) && !/[^\*]\*+[^\*]/.test(cnt)) {
       cnt = cnt[0]=="." ? cnt.replace(".",""): cnt
       cnt = "host-suffix, " + cnt
     } else {


### PR DESCRIPTION
clash 的语法中还存在 `*` 在中间的情况，这是 ChatGPT 给优化的。😂

![image](https://user-images.githubusercontent.com/25895481/230877032-0496a0c8-e91e-430f-941a-067ae16b21fc.png)