### PR TITLE
Update resource-parser.js

### DIFF
--- a/Scripts/resource-parser.js
+++ b/Scripts/resource-parser.js
@@ -1413,37 +1413,45 @@ function Rule_Policy(content) { //增加、替换 policy
 
 // 处理纯列表, 包含 clash-provider
 function rule_list_handle(cnt) {
-    var RuleK = ["//", "#", ";", "[", "!", "/"]
-    const RuleCheck = (item) => cnt.trim().indexOf(item) == 0; //无视注释行
-    const nocheck = (item) => /^\d+$/.test(item) //检查数字项
-    cnt = cnt.split("#")[0].trim() // 去除注释部分
-    if (cnt.trim().indexOf(" ") == -1 && cnt.trim() != "" && !RuleK.some(RuleCheck)) {
-        if (cnt.indexOf("::") != -1 && cnt.indexOf("/") != -1) { // ip-v6?
-            cnt = "ip6-cidr, " + cnt
-            cnt = Ppolicy == "Shawn" ? cnt + ", Shawn" : cnt + ", " + Ppolicy
-        } else if (cnt.split("/").length == 2) {//ip-cidr
-            cnt = "ip-cidr, " + cnt
-            cnt = Ppolicy == "Shawn" ? cnt + ", Shawn" : cnt + ", " + Ppolicy
-        } else if (cnt.split(".").length == 4 && cnt.split(".").every(nocheck)) {  // ip 类规则
-            cnt = "ip-cidr, " + cnt + "/32"
-            cnt = Ppolicy == "Shawn" ? cnt + ", Shawn" : cnt + ", " + Ppolicy
-        } else if (cnt.indexOf("payload:") == -1) { //host - suffix, not clash rule list
-            //$notify("xxx","xxxx",cnt)
-            cnt = cnt.replace(/'|"/g, "").trim()//replace(/'|"|\+\.|\*\.|\*\.\*/g,"") 2023-04-10
-            //clash中以.或*.开头匹配的都是子域名，只存在匹配层级区别，qx中有无此设计不明，只能确定*可用
-            if (/^\.|\*\./.test(cnt)) {//以.开头 = 匹配子域名 .stun.playstation.net/*.stun.playstation.net -> *.stun.playstation.net
-                cnt = "host-wildcard, " + cnt.replace(/^\.|\*\./, "*.")
-            } else if (/^(\+\.)/.test(cnt)) {//以+.开头 = 匹配当前域名及其子域名，走后缀匹配即可 +.xboxlive.com -> suffix xboxlive.com
-                cnt = "host-suffix, " + cnt.replace(/^(\+\.)/, "")
-            } else if (cnt.indexOf("*") != -1) {//不以*.开头的字符串中包含*的情况 -> 保持该规则
-                cnt = "host-wildcard, " + cnt
-            } else {
-                cnt = "host-suffix, " + cnt
-            }
-            cnt = Ppolicy == "Shawn" ? cnt + ", Shawn" : cnt + ", " + Ppolicy
+  var RuleK = ["//", "#", ";", "[", "!", "/"]
+  const RuleCheck = (item) => cnt.trim().indexOf(item) == 0; //无视注释行
+  const nocheck = (item) => /^\d+$/.test(item) //检查数字项
+  cnt = cnt.split("#")[0].trim() // 去除注释部分
+  if (cnt.trim().indexOf(" ") == -1 && cnt.trim() != "" && !RuleK.some(RuleCheck)) {
+    if (cnt.indexOf("::") != -1 && cnt.indexOf("/") != -1) { // ip-v6?
+      cnt = "ip6-cidr, " + cnt
+      cnt = Ppolicy == "Shawn" ? cnt + ", Shawn" : cnt + ", " + Ppolicy
+    } else if (cnt.split("/").length == 2) {//ip-cidr
+      cnt = "ip-cidr, " + cnt
+      cnt = Ppolicy == "Shawn" ? cnt + ", Shawn" : cnt + ", " + Ppolicy
+    } else if (cnt.split(".").length == 4 && cnt.split(".").every(nocheck)) {  // ip 类规则
+      cnt = "ip-cidr, " + cnt + "/32"
+      cnt = Ppolicy == "Shawn" ? cnt + ", Shawn" : cnt + ", " + Ppolicy
+    } else if (cnt.indexOf("payload:") == -1) { //host - suffix, not clash rule list
+      //$notify("xxx","xxxx",cnt)
+      //cnt=cnt.replace(/'|"/g,"").trim()//replace(/'|"|\+\.|\*\.|\*\.\*/g,"") 2023-04-10
+      if (!/^('|")/.test(cnt)) { // not clash-provider
+        if (!/\*|\+/.test(cnt[0])) {
+          cnt = cnt[0] == "." ? cnt.replace(".", "") : cnt
+          cnt = "host-suffix, " + cnt
+        } else {
+          cnt = "host-wildcard, " + cnt
         }
+      } else { // clash provider
+        cnt = cnt.replace(/'|"/g, "").trim()
+
+        if (/^\.|\*\./.test(cnt) || cnt.indexOf("*") != -1) {
+          //1.以.或*.开头 -> 匹配子域名，wildcard,*.domain
+          //2.直接替换开头，正则未匹配 -> 不以*.开头的字符串但包含*的情况(wildcard,a.*.domain...)
+          cnt = "host-wildcard, " + cnt.replace(/^\.|\*\./, "*.")
+        } else {
+          cnt = "host-suffix, " + cnt.replace(/^(\+\.)/, "")//如果以+.开头 = 匹配当前域名及其子域名，采用 suffix,domain。
+        }
+      }
+      cnt = Ppolicy == "Shawn" ? cnt + ", Shawn" : cnt + ", " + Ppolicy
     }
-    return cnt
+  }
+  return cnt
 }
 
 // Domain-Set


### PR DESCRIPTION
对clash rule provider解析做了些修改，更好的转成qx规则(现学的js，不排除存在问题)。

已测试以下规则。
```
payload:
  - '.microsoft.com'
  - '*.microsoft.com'
  - '*microsoft.com'
  - '+.microsoft.com'
  ```