### PR TITLE
fix potential Netflix detection issue

### DIFF
--- a/Scripts/streaming-ui-check.js
+++ b/Scripts/streaming-ui-check.js
@@ -370,6 +370,7 @@ function testNf(filmId) {
         resolve("nf:"+result["Netflix"])
         return 
       }
+      resolve("Netflix Test Error")
     }, reason => {
       result["Netflix"] = "<b>Netflix: </b>检测超时 🚦"
       console.log(result["Netflix"])


### PR DESCRIPTION
Netflix 的检测可能会导致脚本卡住，发现某些情况下返回的状态码为405，导致无法命中 if else