### PR TITLE
fix: proxy config with space character

### DIFF
--- a/Scripts/resource-parser.js
+++ b/Scripts/resource-parser.js
@@ -2844,7 +2844,7 @@ function YAMLFix(cnt){
     //2022-04-11 remove tls|skip from replace(/, (Host|host|path|mux)/g,",   $1")
     console.log("1st:\n"+cnt)
     cnt = cnt.replace(/{\s*name: (.*?), (.*?):/g,"{name: \"$1\", $2:") //cnt.replace(/{\s*name: /g,"{name: \"").replace(/, (.*?):/,"\", $1:")
-    cnt = cnt.replace(/{|}/g,"").replace(/,/g,"\n   ")
+    cnt = cnt.replace(/{\s*|\s*}/g,"").replace(/,/g,"\n   ")
   }
   cnt = cnt.replace(/\n\s*\-\s*\n.*name/g,"\n  - name").replace(/\$|\`/g,"").split("proxy-providers:")[0].split("proxy-groups:")[0].replace(/\"(name|type|server|port|cipher|password|uuid|alterId|udp)(\"*)/g,"$1")
     if(Pdbg == 1) {


### PR DESCRIPTION
some clash configs have a space in {} in the begin and end of the proxy row:
```yaml
proxies:
  - { server: x.x.x.x, port: xxx, name: 'xxx', type: xx, password: xxx, udp: true, alpn: xxx, http/1.1] }
```
this kind of config cannot be parsed correctly.