### PR TITLE
fix: correct 'unkown' to 'unknown' typo in nf-ui-check.js

### DIFF
--- a/Scripts/nf-ui-check.js
+++ b/Scripts/nf-ui-check.js
@@ -110,7 +110,7 @@ function test(filmId) {
         } else if (isPlayable === 'true') {
             resolve({code: 0, content: "Netflix is Ok", region: region})
         } else {
-            resolve({code: 100, content: "unkown error", region: region})
+            resolve({code: 100, content: "unknown error", region: region})
         }
         return
       }


### PR DESCRIPTION
## Summary
Correct spelling error in Scripts/nf-ui-check.js line 113.

**Before:** `resolve({code: 100, content: "unkown error", ...})`
**After:** `resolve({code: 100, content: "unknown error", ...})`

## Context
When the network check encounters an unexpected condition, the error message is returned to the user via the `resolve()` callback. The typo 'unkown' should be 'unknown'.

## Testing
The fix is a single-character correction in a string literal. No functional changes.